### PR TITLE
Missing defaults print schema

### DIFF
--- a/examples/complex-app/federated-schema.graphql
+++ b/examples/complex-app/federated-schema.graphql
@@ -1,17 +1,20 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@shareable", "@inaccessible", "@tag", "@provides", "@requires", "@external", "@extends", "@override"])
+
 input AddPlayerToTeamInput {
-  player: CreatePlayerInput!
   teamId: ID!
+  player: CreatePlayerInput!
 }
 
 input AddPlayersToTeamInput {
-  players: [CreatePlayerInput!]!
   teamId: ID!
+  players: [CreatePlayerInput!]!
 }
 
 input CreateGame {
+  teamId: ID!
   complete: Boolean
   opponentName: String!
-  teamId: ID!
 }
 
 input CreatePlayerInput {
@@ -21,9 +24,9 @@ input CreatePlayerInput {
 
 input CreatePointInput {
   gameId: ID!
-  playerIds: [ID!]!
   scored: Boolean!
   startedOnOffense: Boolean!
+  playerIds: [ID!]!
 }
 
 input CreateTeamInput {
@@ -37,26 +40,26 @@ A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `dat
 scalar DateTime
 
 type Game implements Node {
-  complete: Boolean!
-  createdAt: DateTime!
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  complete: Boolean!
   opponentName: String!
   points: [Point!]!
-  score: GameScore!
   team: Team!
-  updatedAt: DateTime!
+  score: GameScore!
 }
 
 type GameScore {
-  opponentScore: Int!
   ownScore: Int!
+  opponentScore: Int!
 }
 
 type Mutation {
+  createGame(input: CreateGame!): Game!
   addPlayerToTeam(input: AddPlayerToTeamInput!): Team
   addPlayersToTeam(input: AddPlayersToTeamInput!): Team
   addPoint(input: CreatePointInput!): Point
-  createGame(input: CreateGame!): Game!
   createTeam(input: CreateTeamInput!): Team
 }
 
@@ -65,116 +68,108 @@ interface Node {
 }
 
 type PageInfo {
-  endCursor: String
   hasNextPage: Boolean!
   hasPreviousPage: Boolean!
   startCursor: String
+  endCursor: String
 }
 
 type Player implements Node {
-  createdAt: DateTime!
-  games(after: String, before: String, first: Int, last: Int): PlayerGamesConnection!
   id: ID!
-  name: String!
-  points(after: String, before: String, first: Int, last: Int): PlayerPointsConnection!
-  team: Team!
+  createdAt: DateTime!
   updatedAt: DateTime!
+  name: String!
+  team: Team!
+  points(before: String, after: String, first: Int, last: Int): PlayerPointsConnection!
+  games(before: String, after: String, first: Int, last: Int): PlayerGamesConnection!
 }
 
 type PlayerGamesConnection {
-  edges: [PlayerGamesConnectionEdge]!
   pageInfo: PageInfo!
+  edges: [PlayerGamesConnectionEdge]!
 }
 
 type PlayerGamesConnectionEdge {
-  cursor: String!
   node: Game!
+  cursor: String!
 }
 
 type PlayerPointsConnection {
-  edges: [PlayerPointsConnectionEdge]!
   pageInfo: PageInfo!
+  edges: [PlayerPointsConnectionEdge]!
 }
 
 type PlayerPointsConnectionEdge {
-  cursor: String!
   node: Point!
+  cursor: String!
 }
 
 type Point implements Node {
-  createdAt: DateTime!
-  game: Game!
   id: ID!
-  players: [Player!]!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   scored: Boolean!
   startedOnOffense: Boolean!
+  players: [Player!]!
+  game: Game!
   team: Team!
-  updatedAt: DateTime!
 }
 
 type Query {
-  _service: _Service!
-  game(id: ID!): Game
-  games(after: String, before: String, first: Int, last: Int): QueryGamesConnection!
   node(id: ID!): Node
   nodes(ids: [ID!]!): [Node]!
+  games(before: String, after: String, first: Int, last: Int): QueryGamesConnection!
+  game(id: ID!): Game
+  teams(before: String, after: String, first: Int, last: Int): QueryTeamsConnection!
   team(id: ID!): Team
-  teams(after: String, before: String, first: Int, last: Int): QueryTeamsConnection!
 }
 
 type QueryGamesConnection {
-  edges: [QueryGamesConnectionEdge]!
   pageInfo: PageInfo!
+  edges: [QueryGamesConnectionEdge]!
 }
 
 type QueryGamesConnectionEdge {
-  cursor: String!
   node: Game!
+  cursor: String!
 }
 
 type QueryTeamsConnection {
-  edges: [QueryTeamsConnectionEdge]!
   pageInfo: PageInfo!
+  edges: [QueryTeamsConnectionEdge]!
 }
 
 type QueryTeamsConnectionEdge {
-  cursor: String!
   node: Team!
+  cursor: String!
 }
 
 type Team implements Node {
-  createdAt: DateTime!
-  games(after: String, before: String, first: Int, last: Int): TeamGamesConnection!
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   name: String!
   players: [Player!]!
-  points(after: String, before: String, first: Int, last: Int): TeamPointsConnection!
-  updatedAt: DateTime!
+  points(before: String, after: String, first: Int, last: Int): TeamPointsConnection!
+  games(before: String, after: String, first: Int, last: Int): TeamGamesConnection!
 }
 
 type TeamGamesConnection {
-  edges: [TeamGamesConnectionEdge]!
   pageInfo: PageInfo!
+  edges: [TeamGamesConnectionEdge]!
 }
 
 type TeamGamesConnectionEdge {
-  cursor: String!
   node: Game!
+  cursor: String!
 }
 
 type TeamPointsConnection {
-  edges: [TeamPointsConnectionEdge]!
   pageInfo: PageInfo!
+  edges: [TeamPointsConnectionEdge]!
 }
 
 type TeamPointsConnectionEdge {
-  cursor: String!
   node: Point!
-}
-
-type _Service {
-  """
-  The sdl representing the federated service capabilities. Includes federation directives, removes federation types, and includes rest of full schema after schema directives have been applied
-  """
-  sdl: String
+  cursor: String!
 }

--- a/examples/complex-app/federated-schema.graphql
+++ b/examples/complex-app/federated-schema.graphql
@@ -24,8 +24,9 @@ input CreatePlayerInput {
 
 input CreatePointInput {
   gameId: ID!
-  scored: Boolean
+  scored: Boolean = false
   startedOnOffense: Boolean!
+  order: Sort = ASC
   playerIds: [ID!]!
 }
 
@@ -59,7 +60,7 @@ type Mutation {
   createGame(input: CreateGame!): Game!
   addPlayerToTeam(input: AddPlayerToTeamInput!): Team
   addPlayersToTeam(input: AddPlayersToTeamInput!): Team
-  addPoint(input: CreatePointInput!): Point
+  addPoint(input: CreatePointInput = {}): Point
   createTeam(input: CreateTeamInput!): Team
 }
 
@@ -142,6 +143,11 @@ type QueryTeamsConnection {
 type QueryTeamsConnectionEdge {
   node: Team!
   cursor: String!
+}
+
+enum Sort {
+  ASC
+  DESC
 }
 
 type Team implements Node {

--- a/examples/complex-app/federated-schema.graphql
+++ b/examples/complex-app/federated-schema.graphql
@@ -24,7 +24,7 @@ input CreatePlayerInput {
 
 input CreatePointInput {
   gameId: ID!
-  scored: Boolean!
+  scored: Boolean
   startedOnOffense: Boolean!
   playerIds: [ID!]!
 }

--- a/examples/complex-app/package.json
+++ b/examples/complex-app/package.json
@@ -16,6 +16,7 @@
     "seed": "node -r @swc-node/register prisma/seed.ts"
   },
   "dependencies": {
+    "@apollo/subgraph": "2.3.2",
     "@faker-js/faker": "^7.6.0",
     "@graphql-typed-document-node/core": "^3.1.1",
     "@pothos/core": "^3.25.0",
@@ -26,6 +27,8 @@
     "@pothos/plugin-scope-auth": "workspace:*",
     "@pothos/plugin-simple-objects": "workspace:*",
     "@pothos/plugin-validation": "workspace:*",
+    "@pothos/plugin-directives": "workspace:*",
+    "@pothos/plugin-federation": "workspace:*",
     "@prisma/client": "^4.9.0",
     "graphql": "16.6.0",
     "graphql-scalars": "^1.20.1",

--- a/examples/complex-app/schema.graphql
+++ b/examples/complex-app/schema.graphql
@@ -22,7 +22,7 @@ input CreatePlayerInput {
 input CreatePointInput {
   gameId: ID!
   playerIds: [ID!]!
-  scored: Boolean!
+  scored: Boolean = false
   startedOnOffense: Boolean!
 }
 

--- a/examples/complex-app/schema.graphql
+++ b/examples/complex-app/schema.graphql
@@ -21,6 +21,7 @@ input CreatePlayerInput {
 
 input CreatePointInput {
   gameId: ID!
+  order: Sort = ASC
   playerIds: [ID!]!
   scored: Boolean = false
   startedOnOffense: Boolean!
@@ -55,7 +56,7 @@ type GameScore {
 type Mutation {
   addPlayerToTeam(input: AddPlayerToTeamInput!): Team
   addPlayersToTeam(input: AddPlayersToTeamInput!): Team
-  addPoint(input: CreatePointInput!): Point
+  addPoint(input: CreatePointInput = {}): Point
   createGame(input: CreateGame!): Game!
   createTeam(input: CreateTeamInput!): Team
 }
@@ -140,6 +141,11 @@ type QueryTeamsConnection {
 type QueryTeamsConnectionEdge {
   cursor: String!
   node: Team!
+}
+
+enum Sort {
+  ASC
+  DESC
 }
 
 type Team implements Node {

--- a/examples/complex-app/scripts/build-schema.ts
+++ b/examples/complex-app/scripts/build-schema.ts
@@ -1,6 +1,12 @@
 import { writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { printSchema } from 'graphql';
+import { printSubgraphSchema } from '@apollo/subgraph';
 import { schema } from '../src/schema';
 
 writeFileSync(resolve(module.filename, '../../schema.graphql'), printSchema(schema));
+
+writeFileSync(
+  resolve(module.filename, '../../federated-schema.graphql'),
+  printSubgraphSchema(schema),
+);

--- a/examples/complex-app/src/builder.ts
+++ b/examples/complex-app/src/builder.ts
@@ -7,6 +7,8 @@ import RelayPlugin from '@pothos/plugin-relay';
 import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
 import SimpleObjectsPlugin from '@pothos/plugin-simple-objects';
 import ValidationPlugin from '@pothos/plugin-validation';
+import DirectivePlugin from '@pothos/plugin-directives';
+import FederationPlugin from '@pothos/plugin-federation';
 import type PrismaTypes from '../prisma/generated';
 import { db } from './db';
 
@@ -31,6 +33,8 @@ export const builder = new SchemaBuilder<{
     DataloaderPlugin,
     SimpleObjectsPlugin,
     ValidationPlugin,
+    DirectivePlugin,
+    FederationPlugin,
   ],
   authScopes: () => ({}),
   relayOptions: {

--- a/examples/complex-app/src/schema/index.ts
+++ b/examples/complex-app/src/schema/index.ts
@@ -4,4 +4,4 @@ import './point';
 import './team';
 import { builder } from '../builder';
 
-export const schema = builder.toSchema();
+export const schema = builder.toSubGraphSchema({});

--- a/examples/complex-app/src/schema/point.ts
+++ b/examples/complex-app/src/schema/point.ts
@@ -23,6 +23,12 @@ export const AddPointInput = builder.inputType('CreatePointInput', {
     gameId: t.id({ required: true }),
     scored: t.boolean({ required: false, defaultValue: false }),
     startedOnOffense: t.boolean({ required: true }),
+    order: t.field({
+      defaultValue: 'ASC',
+      type: builder.enumType('Sort', {
+        values: ['ASC', 'DESC'] as const,
+      }),
+    }),
     playerIds: t.idList({ required: true }),
   }),
 });
@@ -32,7 +38,7 @@ builder.mutationField('addPoint', (t) =>
     type: 'Point',
     nullable: true,
     args: {
-      input: t.arg({ type: AddPointInput, required: true }),
+      input: t.arg({ type: AddPointInput, required: false, defaultValue: {} }),
     },
     resolve: async (query, _, { input }) => {
       const game = await db.game.findUniqueOrThrow({ where: { id: parseID(input.gameId) } });

--- a/examples/complex-app/src/schema/point.ts
+++ b/examples/complex-app/src/schema/point.ts
@@ -21,7 +21,7 @@ builder.prismaNode('Point', {
 export const AddPointInput = builder.inputType('CreatePointInput', {
   fields: (t) => ({
     gameId: t.id({ required: true }),
-    scored: t.boolean({ required: true }),
+    scored: t.boolean({ required: false, defaultValue: false }),
     startedOnOffense: t.boolean({ required: true }),
     playerIds: t.idList({ required: true }),
   }),

--- a/packages/deno/packages/plugin-directives/mock-ast.ts
+++ b/packages/deno/packages/plugin-directives/mock-ast.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /* eslint-disable no-param-reassign */
 import './global-types.ts';
-import { ArgumentNode, ConstDirectiveNode, DirectiveNode, EnumValueDefinitionNode, FieldDefinitionNode, GraphQLArgument, GraphQLEnumType, GraphQLEnumValue, GraphQLField, GraphQLFieldMap, GraphQLInputField, GraphQLInputFieldMap, GraphQLInputObjectType, GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLScalarType, GraphQLSchema, GraphQLType, GraphQLUnionType, InputValueDefinitionNode, Kind, ListTypeNode, NamedTypeNode, OperationTypeNode, parseValue, TypeNode, ValueNode, } from 'https://cdn.skypack.dev/graphql?dts';
+import { ArgumentNode, astFromValue, ConstDirectiveNode, ConstValueNode, DirectiveNode, EnumValueDefinitionNode, FieldDefinitionNode, GraphQLArgument, GraphQLEnumType, GraphQLEnumValue, GraphQLField, GraphQLFieldMap, GraphQLInputField, GraphQLInputFieldMap, GraphQLInputObjectType, GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLScalarType, GraphQLSchema, GraphQLType, GraphQLUnionType, InputValueDefinitionNode, Kind, ListTypeNode, NamedTypeNode, OperationTypeNode, parseValue, TypeNode, ValueNode, } from 'https://cdn.skypack.dev/graphql?dts';
 import type { DirectiveList } from './types.ts';
 export default function mockAst(schema: GraphQLSchema) {
     const types = schema.getTypeMap();
@@ -175,10 +175,12 @@ function fieldNodes(fields: GraphQLFieldMap<unknown, unknown>): FieldDefinitionN
 function inputFieldNodes(fields: GraphQLInputFieldMap): InputValueDefinitionNode[] {
     return Object.keys(fields).map((fieldName) => {
         const field: GraphQLInputField = fields[fieldName];
+        const defaultValueNode = astFromValue(field.defaultValue, field.type) as ConstValueNode;
         field.astNode = {
             kind: Kind.INPUT_VALUE_DEFINITION,
             description: field.description ? { kind: Kind.STRING, value: field.description } : undefined,
             name: { kind: Kind.NAME, value: fieldName },
+            defaultValue: field.defaultValue === undefined ? undefined : defaultValueNode,
             type: typeNode(field.type),
             directives: directiveNodes(field.extensions?.directives as DirectiveList, field.deprecationReason),
         };
@@ -187,10 +189,12 @@ function inputFieldNodes(fields: GraphQLInputFieldMap): InputValueDefinitionNode
 }
 function argumentNodes(args: readonly GraphQLArgument[]): InputValueDefinitionNode[] {
     return args.map((arg): InputValueDefinitionNode => {
+        const defaultValueNode = astFromValue(arg.defaultValue, arg.type) as ConstValueNode;
         arg.astNode = {
             kind: Kind.INPUT_VALUE_DEFINITION,
             description: arg.description ? { kind: Kind.STRING, value: arg.description } : undefined,
             name: { kind: Kind.NAME, value: arg.name },
+            defaultValue: arg.defaultValue === undefined ? undefined : defaultValueNode,
             type: typeNode(arg.type),
             directives: directiveNodes(arg.extensions?.directives as DirectiveList, arg.deprecationReason),
         };

--- a/packages/plugin-directives/src/mock-ast.ts
+++ b/packages/plugin-directives/src/mock-ast.ts
@@ -4,7 +4,9 @@
 import './global-types';
 import {
   ArgumentNode,
+  astFromValue,
   ConstDirectiveNode,
+  ConstValueNode,
   DirectiveNode,
   EnumValueDefinitionNode,
   FieldDefinitionNode,
@@ -237,10 +239,13 @@ function inputFieldNodes(fields: GraphQLInputFieldMap): InputValueDefinitionNode
   return Object.keys(fields).map((fieldName) => {
     const field: GraphQLInputField = fields[fieldName];
 
+    const defaultValueNode = astFromValue(field.defaultValue, field.type) as ConstValueNode;
+
     field.astNode = {
       kind: Kind.INPUT_VALUE_DEFINITION,
       description: field.description ? { kind: Kind.STRING, value: field.description } : undefined,
       name: { kind: Kind.NAME, value: fieldName },
+      defaultValue: field.defaultValue === undefined ? undefined : defaultValueNode,
       type: typeNode(field.type),
       directives: directiveNodes(
         field.extensions?.directives as DirectiveList,
@@ -254,10 +259,13 @@ function inputFieldNodes(fields: GraphQLInputFieldMap): InputValueDefinitionNode
 
 function argumentNodes(args: readonly GraphQLArgument[]): InputValueDefinitionNode[] {
   return args.map((arg): InputValueDefinitionNode => {
+    const defaultValueNode = astFromValue(arg.defaultValue, arg.type) as ConstValueNode;
+
     arg.astNode = {
       kind: Kind.INPUT_VALUE_DEFINITION,
       description: arg.description ? { kind: Kind.STRING, value: arg.description } : undefined,
       name: { kind: Kind.NAME, value: arg.name },
+      defaultValue: arg.defaultValue === undefined ? undefined : defaultValueNode,
       type: typeNode(arg.type),
       directives: directiveNodes(
         arg.extensions?.directives as DirectiveList,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,7 @@ importers:
 
   examples/complex-app:
     specifiers:
+      '@apollo/subgraph': 2.3.2
       '@faker-js/faker': ^7.6.0
       '@graphql-codegen/cli': 3.0.0
       '@graphql-codegen/client-preset': 2.0.0
@@ -64,6 +65,8 @@ importers:
       '@graphql-typed-document-node/core': ^3.1.1
       '@pothos/core': ^3.25.0
       '@pothos/plugin-dataloader': workspace:*
+      '@pothos/plugin-directives': workspace:*
+      '@pothos/plugin-federation': workspace:*
       '@pothos/plugin-prisma': workspace:*
       '@pothos/plugin-prisma-utils': workspace:*
       '@pothos/plugin-relay': workspace:*
@@ -78,10 +81,13 @@ importers:
       typescript: ^4.9.5
       urql: ^3.0.3
     dependencies:
+      '@apollo/subgraph': 2.3.2_graphql@16.6.0
       '@faker-js/faker': 7.6.0
       '@graphql-typed-document-node/core': 3.1.1_graphql@16.6.0
       '@pothos/core': link:../../packages/core
       '@pothos/plugin-dataloader': link:../../packages/plugin-dataloader
+      '@pothos/plugin-directives': link:../../packages/plugin-directives
+      '@pothos/plugin-federation': link:../../packages/plugin-federation
       '@pothos/plugin-prisma': link:../../packages/plugin-prisma
       '@pothos/plugin-prisma-utils': link:../../packages/plugin-prisma-utils
       '@pothos/plugin-relay': link:../../packages/plugin-relay


### PR DESCRIPTION
### Description
Added a reproduction of a _potential_ bug in the `printSubgraphSchema` from `@apollo/subgraph`. It seems the printing method doesn't include default values, where the `printSchema` from `graphql` does that. Please check this commit https://github.com/moonflare/pothos/commit/459b853389142cb85347a2cfc129c309ae166bfa to see the difference between the output of the two printing methods.